### PR TITLE
Fix balance service error: 'str' object has no attribute 'value'

### DIFF
--- a/src/cogs/admin_balance.py
+++ b/src/cogs/admin_balance.py
@@ -11,6 +11,7 @@ from src.cogs.admin_base import AdminBaseCog
 from src.services.balance_service import BalanceManagerService
 from src.utils.formatters import message_formatter
 from src.utils.validators import input_validator
+from src.config.constants.bot_constants import TransactionType
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +48,7 @@ class AdminBalanceCog(AdminBaseCog):
                 wl=wl,
                 dl=dl,
                 bgl=bgl,
-                transaction_type="admin_add"
+                transaction_type=TransactionType.ADMIN_ADD
             )
             
             if response.success:
@@ -91,7 +92,7 @@ class AdminBalanceCog(AdminBaseCog):
                 wl=wl,
                 dl=dl,
                 bgl=bgl,
-                transaction_type="admin_remove"
+                transaction_type=TransactionType.ADMIN_REMOVE
             )
             
             if response.success:

--- a/src/services/balance_service.py
+++ b/src/services/balance_service.py
@@ -519,6 +519,12 @@ class BalanceManagerService(BaseLockHandler):
                     (normalized_new_balance.wl, normalized_new_balance.dl, normalized_new_balance.bgl, growid)
                 )
                 
+                # Handle both enum and string transaction types
+                if isinstance(transaction_type, TransactionType):
+                    transaction_type_value = transaction_type.value
+                else:
+                    transaction_type_value = str(transaction_type)
+                
                 cursor.execute(
                     """
                     INSERT INTO balance_transactions 
@@ -527,7 +533,7 @@ class BalanceManagerService(BaseLockHandler):
                     """,
                     (
                         growid,
-                        transaction_type.value, 
+                        transaction_type_value, 
                         details,
                         current_balance.format(),
                         normalized_new_balance.format()

--- a/src/services/transaction_service.py
+++ b/src/services/transaction_service.py
@@ -229,7 +229,7 @@ class TransactionManager(BaseLockHandler):
                 growid=growid,
                 wl=-total_price,
                 details=f"Purchase {quantity}x {product['name']}",
-                transaction_type=TransactionType.PURCHASE.value
+                transaction_type=TransactionType.PURCHASE
             )
             if not balance_update_response.success:
                 # Rollback stock status if balance update fails
@@ -347,7 +347,7 @@ class TransactionManager(BaseLockHandler):
                 dl=dl,
                 bgl=bgl,
                 details=details,
-                transaction_type=TransactionType.DEPOSIT.value
+                transaction_type=TransactionType.DEPOSIT
             )
             if not balance_response.success:
                 return TransactionResponse.error(balance_response.error)
@@ -455,7 +455,7 @@ class TransactionManager(BaseLockHandler):
                 dl=-dl,
                 bgl=-bgl,
                 details=details,
-                transaction_type=TransactionType.WITHDRAWAL.value
+                transaction_type=TransactionType.WITHDRAWAL
             )
             if not balance_response.success:
                 return TransactionResponse.error(balance_response.error)


### PR DESCRIPTION
- Fixed transaction_service.py: Remove .value from TransactionType enums before passing to update_balance()
- Fixed admin_balance.py: Use TransactionType enums instead of strings
- Added defensive programming in balance_service.py to handle both enum and string inputs
- Resolves error in balance_service.py:573 where transaction_type.value was called on a string